### PR TITLE
Add release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,21 @@
+name: release
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+        - uses: actions/checkout@v4
+        - name: Install uv
+          uses: astral-sh/setup-uv@v5
+        - name: "Set up Python"
+          uses: actions/setup-python@v5
+          with:
+            python-version-file: "pyproject.toml"
+        - name: "Build"
+          uses: uv build
+        - name: "Publish"
+          uses: uv publish


### PR DESCRIPTION
This adds a GitHub action for automatic release to PyPI once a GitHub release is created.

Once the action is merged, you can configure the [PyPI publisher](https://docs.pypi.org/trusted-publishers/adding-a-publisher/) to authenticate the action.